### PR TITLE
Yahtzee gesplitst in Controller, Model en View

### DIFF
--- a/Yahtzee/Program.cs
+++ b/Yahtzee/Program.cs
@@ -16,7 +16,7 @@ namespace Yahtzee
 		{
 			Application.EnableVisualStyles();
 			Application.SetCompatibleTextRenderingDefault(false);
-			Application.Run(new Yahtzee());
+      Application.Run(new YahtzeeStart());
 		}
 	}
 }

--- a/Yahtzee/ScoreboardController.cs
+++ b/Yahtzee/ScoreboardController.cs
@@ -9,7 +9,6 @@ namespace Yahtzee
 	public class ScoreboardController
 	{
 		private ScoreboardView view;
-
 		public ScoreboardModel model;
 
 		public ScoreboardController()

--- a/Yahtzee/ScoreboardGlobalPlayerView.Designer.cs
+++ b/Yahtzee/ScoreboardGlobalPlayerView.Designer.cs
@@ -1,0 +1,87 @@
+﻿namespace Yahtzee
+{
+  partial class ScoreboardGlobalPlayerView
+  {
+    /// <summary> 
+    /// Required designer variable.
+    /// </summary>
+    private System.ComponentModel.IContainer components = null;
+
+    /// <summary> 
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+      if (disposing && (components != null))
+      {
+        components.Dispose();
+      }
+      base.Dispose(disposing);
+    }
+
+    #region Component Designer generated code
+
+    /// <summary> 
+    /// Required method for Designer support - do not modify 
+    /// the contents of this method with the code editor.
+    /// </summary>
+    private void InitializeComponent()
+    {
+      this.winLoseLabel = new System.Windows.Forms.Label();
+      this.lblScore = new System.Windows.Forms.Label();
+      this.playerLabel = new System.Windows.Forms.Label();
+      this.SuspendLayout();
+      // 
+      // winLoseLabel
+      // 
+      this.winLoseLabel.AutoSize = true;
+      this.winLoseLabel.Location = new System.Drawing.Point(47, 100);
+      this.winLoseLabel.Name = "winLoseLabel";
+      this.winLoseLabel.Padding = new System.Windows.Forms.Padding(0, 5, 0, 5);
+      this.winLoseLabel.Size = new System.Drawing.Size(26, 23);
+      this.winLoseLabel.TabIndex = 3;
+      this.winLoseLabel.Text = "Win";
+      // 
+      // lblScore
+      // 
+      this.lblScore.AutoSize = true;
+      this.lblScore.Location = new System.Drawing.Point(39, 48);
+      this.lblScore.Name = "lblScore";
+      this.lblScore.Padding = new System.Windows.Forms.Padding(0, 5, 0, 5);
+      this.lblScore.Size = new System.Drawing.Size(47, 23);
+      this.lblScore.TabIndex = 2;
+      this.lblScore.Text = "Score: 0";
+      // 
+      // playerLabel
+      // 
+      this.playerLabel.AutoSize = true;
+      this.playerLabel.Location = new System.Drawing.Point(40, 19);
+      this.playerLabel.Name = "playerLabel";
+      this.playerLabel.Padding = new System.Windows.Forms.Padding(0, 5, 0, 5);
+      this.playerLabel.Size = new System.Drawing.Size(36, 23);
+      this.playerLabel.TabIndex = 4;
+      this.playerLabel.Text = "Player";
+      // 
+      // ScoreboardGlobalPlayerView
+      // 
+      this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+      this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+      this.Controls.Add(this.playerLabel);
+      this.Controls.Add(this.winLoseLabel);
+      this.Controls.Add(this.lblScore);
+      this.Name = "ScoreboardGlobalPlayerView";
+      this.Size = new System.Drawing.Size(133, 152);
+      this.Load += new System.EventHandler(this.ScoreboardGlobalPlayerView_Load);
+      this.ResumeLayout(false);
+      this.PerformLayout();
+
+    }
+
+    #endregion
+
+    private System.Windows.Forms.Label winLoseLabel;
+    private System.Windows.Forms.Label lblScore;
+    private System.Windows.Forms.Label playerLabel;
+  }
+}

--- a/Yahtzee/ScoreboardGlobalPlayerView.cs
+++ b/Yahtzee/ScoreboardGlobalPlayerView.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Yahtzee
+{
+  public partial class ScoreboardGlobalPlayerView : UserControl
+  {
+    public ScoreboardGlobalPlayerView()
+    {
+      InitializeComponent();
+    }
+
+    private void ScoreboardGlobalPlayerView_Load(object sender, EventArgs e)
+    {
+
+    }
+  }
+}

--- a/Yahtzee/ScoreboardGlobalPlayerView.resx
+++ b/Yahtzee/ScoreboardGlobalPlayerView.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Yahtzee/ScoreboardView.Designer.cs
+++ b/Yahtzee/ScoreboardView.Designer.cs
@@ -28,37 +28,37 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.lblScore = new System.Windows.Forms.Label();
-			this.lblHighscore = new System.Windows.Forms.Label();
-			this.SuspendLayout();
-			// 
-			// lblScore
-			// 
-			this.lblScore.AutoSize = true;
-			this.lblScore.Location = new System.Drawing.Point(45, 29);
-			this.lblScore.Name = "lblScore";
-			this.lblScore.Size = new System.Drawing.Size(47, 13);
-			this.lblScore.TabIndex = 0;
-			this.lblScore.Text = "Score: 0";
-			// 
-			// lblHighscore
-			// 
-			this.lblHighscore.AutoSize = true;
-			this.lblHighscore.Location = new System.Drawing.Point(48, 87);
-			this.lblHighscore.Name = "lblHighscore";
-			this.lblHighscore.Size = new System.Drawing.Size(67, 13);
-			this.lblHighscore.TabIndex = 1;
-			this.lblHighscore.Text = "Highscore: 0";
-			// 
-			// ScoreboardView
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.Controls.Add(this.lblHighscore);
-			this.Controls.Add(this.lblScore);
-			this.Name = "ScoreboardView";
-			this.ResumeLayout(false);
-			this.PerformLayout();
+      this.lblScore = new System.Windows.Forms.Label();
+      this.lblHighscore = new System.Windows.Forms.Label();
+      this.SuspendLayout();
+      // 
+      // lblScore
+      // 
+      this.lblScore.AutoSize = true;
+      this.lblScore.Location = new System.Drawing.Point(45, 29);
+      this.lblScore.Name = "lblScore";
+      this.lblScore.Size = new System.Drawing.Size(47, 13);
+      this.lblScore.TabIndex = 0;
+      this.lblScore.Text = "Score: 0";
+      // 
+      // lblHighscore
+      // 
+      this.lblHighscore.AutoSize = true;
+      this.lblHighscore.Location = new System.Drawing.Point(36, 87);
+      this.lblHighscore.Name = "lblHighscore";
+      this.lblHighscore.Size = new System.Drawing.Size(67, 13);
+      this.lblHighscore.TabIndex = 1;
+      this.lblHighscore.Text = "Highscore: 0";
+      // 
+      // ScoreboardView
+      // 
+      this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+      this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+      this.Controls.Add(this.lblHighscore);
+      this.Controls.Add(this.lblScore);
+      this.Name = "ScoreboardView";
+      this.ResumeLayout(false);
+      this.PerformLayout();
 
 		}
 

--- a/Yahtzee/TeerlingController.cs
+++ b/Yahtzee/TeerlingController.cs
@@ -9,15 +9,17 @@ namespace Yahtzee
     //member die de view opvangt  
 		private TeerlingView view; 
 		public TeerlingModel model;
-		Yahtzee yahtzeeclass;
+		YahtzeeController yahtzeeController;
+    private int throwns;
 
-		public TeerlingController(int i, Yahtzee y)
+    public TeerlingController(int i, YahtzeeController y)
 		{
 			view = new TeerlingView(this);
 			model = new TeerlingModel();
 			model.IndexOfTeerling = i;
 			view.SetIndexOfTeerling();
-			yahtzeeclass = y;
+      yahtzeeController = y;
+      throwns = model.AantalWorpen;
 		}
 
 		public TeerlingView getView()
@@ -27,8 +29,11 @@ namespace Yahtzee
 
 		public void Werp()
 		{
+      throwns++;
+      model.AantalWorpen = throwns;
+      
 			if (!model.Vastgezet)
-			{
+      {
 				//Nieuwe instantie van Random object genereren
 				Random random = new Random(seed++);
 
@@ -38,6 +43,11 @@ namespace Yahtzee
 				//Het model updaten
 				model.AantalOgen = aantalOgen;
 			}
+
+      if (throwns ==3)
+      {
+        view.DisableThrow();
+      }
 		}
 
 		public void Vastzetten()
@@ -49,7 +59,7 @@ namespace Yahtzee
 
 		public void ScoreChanged()
 		{
-			yahtzeeclass.ScoreChanged();
+      yahtzeeController.ScoreChanged(model.IndexOfTeerling);
 		}
 	}
 }

--- a/Yahtzee/TeerlingModel.cs
+++ b/Yahtzee/TeerlingModel.cs
@@ -9,6 +9,7 @@ namespace Yahtzee
 		private bool vastgezet = false;
 		private bool btnIsVisible = true;
 		private int indexOfTeerling = 0;
+    private int aantalWorpen = 0;
 
 		public int AantalOgen { 
       get {	return aantalOgen; }
@@ -34,5 +35,11 @@ namespace Yahtzee
 			get { return indexOfTeerling; }
 			set { indexOfTeerling = value; }
 		}
+
+    public int AantalWorpen {
+      get { return aantalWorpen; }
+      set { aantalWorpen = value; }
+    }  
+
 	}
 }

--- a/Yahtzee/TeerlingView.cs
+++ b/Yahtzee/TeerlingView.cs
@@ -5,7 +5,6 @@ namespace Yahtzee
 {
 	public partial class TeerlingView : UserControl
 	{
-		private int throwns = 0;
 		private TeerlingController controller;
 
 		public TeerlingView(TeerlingController c)
@@ -22,18 +21,12 @@ namespace Yahtzee
 
 		public void SetText()
 		{
-      throwns++;
       controller.Werp();
       int nieuwAantalOgen = controller.model.AantalOgen;
       TeerlingLabel.Text = nieuwAantalOgen.ToString();
-
-			if (throwns == 3)
-			{
-        DisableThrow();
-			}
 		}
 
-    private void DisableThrow()
+    public void DisableThrow()
     {
       controller.Vastzetten();
       TeerlingLabel.ForeColor = controller.model.KleurTeerling;

--- a/Yahtzee/Yahtzee.Designer.cs
+++ b/Yahtzee/Yahtzee.Designer.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace Yahtzee
 {
-	partial class Yahtzee
+	partial class YahtzeeView
 	{
 		/// <summary>
 		/// Required designer variable.
@@ -29,59 +29,59 @@ namespace Yahtzee
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-			this.button1 = new System.Windows.Forms.Button();
-			this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
-			this.flowLayoutPanel1.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// flowLayoutPanel1
-			// 
-			this.flowLayoutPanel1.AutoSize = true;
-			this.flowLayoutPanel1.Controls.Add(this.button1);
-			this.flowLayoutPanel1.Controls.Add(this.flowLayoutPanel2);
-			this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-			this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-			this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(20);
-			this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-			this.flowLayoutPanel1.Size = new System.Drawing.Size(300, 261);
-			this.flowLayoutPanel1.TabIndex = 0;
-			// 
-			// button1
-			// 
-			this.button1.AutoSize = true;
-			this.button1.Dock = System.Windows.Forms.DockStyle.Left;
-			this.button1.Location = new System.Drawing.Point(3, 3);
-			this.button1.Name = "button1";
-			this.button1.Size = new System.Drawing.Size(67, 23);
-			this.button1.TabIndex = 0;
-			this.button1.Text = "Werp alles";
-			this.button1.UseVisualStyleBackColor = true;
-			this.button1.Click += new System.EventHandler(this.button1_Click);
-			// 
-			// flowLayoutPanel2
-			// 
-			this.flowLayoutPanel2.AutoSize = true;
-			this.flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.flowLayoutPanel2.Location = new System.Drawing.Point(3, 32);
-			this.flowLayoutPanel2.Name = "flowLayoutPanel2";
-			this.flowLayoutPanel2.Size = new System.Drawing.Size(67, 0);
-			this.flowLayoutPanel2.TabIndex = 0;
-			// 
-			// Yahtzee
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.AutoSize = true;
-			this.ClientSize = new System.Drawing.Size(300, 261);
-			this.Controls.Add(this.flowLayoutPanel1);
-			this.Name = "Yahtzee";
-			this.Text = "Form1";
-			this.flowLayoutPanel1.ResumeLayout(false);
-			this.flowLayoutPanel1.PerformLayout();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+      this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+      this.button1 = new System.Windows.Forms.Button();
+      this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
+      this.flowLayoutPanel1.SuspendLayout();
+      this.SuspendLayout();
+      // 
+      // flowLayoutPanel1
+      // 
+      this.flowLayoutPanel1.AutoSize = true;
+      this.flowLayoutPanel1.Controls.Add(this.button1);
+      this.flowLayoutPanel1.Controls.Add(this.flowLayoutPanel2);
+      this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+      this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+      this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+      this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(20);
+      this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+      this.flowLayoutPanel1.Size = new System.Drawing.Size(300, 261);
+      this.flowLayoutPanel1.TabIndex = 0;
+      // 
+      // button1
+      // 
+      this.button1.AutoSize = true;
+      this.button1.Dock = System.Windows.Forms.DockStyle.Left;
+      this.button1.Location = new System.Drawing.Point(3, 3);
+      this.button1.Name = "button1";
+      this.button1.Size = new System.Drawing.Size(67, 23);
+      this.button1.TabIndex = 0;
+      this.button1.Text = "Werp alles";
+      this.button1.UseVisualStyleBackColor = true;
+      this.button1.Click += new System.EventHandler(this.button1_Click);
+      // 
+      // flowLayoutPanel2
+      // 
+      this.flowLayoutPanel2.AutoSize = true;
+      this.flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+      this.flowLayoutPanel2.Location = new System.Drawing.Point(3, 32);
+      this.flowLayoutPanel2.Name = "flowLayoutPanel2";
+      this.flowLayoutPanel2.Size = new System.Drawing.Size(67, 0);
+      this.flowLayoutPanel2.TabIndex = 0;
+      // 
+      // YahtzeeView
+      // 
+      this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+      this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+      this.AutoSize = true;
+      this.ClientSize = new System.Drawing.Size(300, 261);
+      this.Controls.Add(this.flowLayoutPanel1);
+      this.Name = "YahtzeeView";
+      this.Text = "Player";
+      this.flowLayoutPanel1.ResumeLayout(false);
+      this.flowLayoutPanel1.PerformLayout();
+      this.ResumeLayout(false);
+      this.PerformLayout();
 
 		}
 

--- a/Yahtzee/Yahtzee.cs
+++ b/Yahtzee/Yahtzee.cs
@@ -4,52 +4,34 @@ using System.Windows.Forms;
 
 namespace Yahtzee
 {
-	public partial class Yahtzee : Form
+	public partial class YahtzeeView : Form
 	{
-		private List<TeerlingController> teerlingen = new List<TeerlingController>();
-		private const int aantalTeerlingen = 6, aantalWorpen = 0;
-		ScoreboardController Scoreboard = new ScoreboardController();
-		public Yahtzee()
+		private YahtzeeController controller;
+
+    public YahtzeeView(YahtzeeController c)
 		{
 			InitializeComponent();
-
-			for (int i = 0; i < aantalTeerlingen; i++)
-			{
-				//Maak instantie aan van TeerlingController
-				//Voeg teerling toe aan het formulier
-				teerlingen.Add(new TeerlingController(i, this));
-
-				TeerlingView teerlingView = teerlingen[i].getView();
-				teerlingView.Location = new System.Drawing.Point(i * teerlingView.Width, teerlingView.Location.Y);
-				flowLayoutPanel2.Controls.Add(teerlingView);
-
-			}
-
-      Scoreboard.model.Numbers = new int[aantalTeerlingen]; 
-			ScoreboardView scoreboardView = Scoreboard.getView();
-			scoreboardView.Location = new System.Drawing.Point(5, 5);
-			flowLayoutPanel1.Controls.Add(scoreboardView);
+			controller = c;
+      MakeScoreboard();
 		}
-
-		public void ScoreChanged()
-		{
-			for (int i = 0; i < aantalTeerlingen; i++)
-			{
-				Scoreboard.ChangeScore(i, teerlingen[i].model.AantalOgen);
-			}
-			Scoreboard.UpdateScore();
-		}
-
+	
 		private void button1_Click(object sender, EventArgs e)
 		{
-
-			for (int i = 0; i < aantalTeerlingen; i++)
-			{
-				teerlingen[i].getView().SetText();
-				Scoreboard.ChangeScore(i, teerlingen[i].model.AantalOgen);
-			}
-			Scoreboard.UpdateScore();
-
+      controller.ScoreChangedAll();
 		}
+
+    public void MakeDice(TeerlingView teerlingView, int i) //Laat teerlingen verschijnen
+    {
+      teerlingView.Location = new System.Drawing.Point(i * teerlingView.Width, teerlingView.Location.Y);
+      flowLayoutPanel2.Controls.Add(teerlingView);
+    }
+
+    public void MakeScoreboard() //laat scoreboard verschijnen
+    {
+      ScoreboardView scoreView = controller.GetScoreView();
+      scoreView.Location = new System.Drawing.Point(100, 100);
+      flowLayoutPanel1.Controls.Add(scoreView);
+    }
+
 	}
 }

--- a/Yahtzee/Yahtzee.csproj
+++ b/Yahtzee/Yahtzee.csproj
@@ -51,6 +51,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ScoreboardController.cs" />
+    <Compile Include="ScoreboardGlobalPlayerView.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="ScoreboardGlobalPlayerView.Designer.cs">
+      <DependentUpon>ScoreboardGlobalPlayerView.cs</DependentUpon>
+    </Compile>
     <Compile Include="ScoreboardModel.cs" />
     <Compile Include="ScoreboardView.cs">
       <SubType>UserControl</SubType>
@@ -74,6 +80,17 @@
     <Compile Include="TeerlingView.Designer.cs">
       <DependentUpon>TeerlingView.cs</DependentUpon>
     </Compile>
+    <Compile Include="YahtzeeController.cs" />
+    <Compile Include="YahtzeeModel.cs" />
+    <Compile Include="YahtzeeStart.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="YahtzeeStart.Designer.cs">
+      <DependentUpon>YahtzeeStart.cs</DependentUpon>
+    </Compile>
+    <EmbeddedResource Include="ScoreboardGlobalPlayerView.resx">
+      <DependentUpon>ScoreboardGlobalPlayerView.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="ScoreboardView.resx">
       <DependentUpon>ScoreboardView.cs</DependentUpon>
     </EmbeddedResource>
@@ -92,6 +109,9 @@
     </Compile>
     <EmbeddedResource Include="TeerlingView.resx">
       <DependentUpon>TeerlingView.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="YahtzeeStart.resx">
+      <DependentUpon>YahtzeeStart.cs</DependentUpon>
     </EmbeddedResource>
     <None Include="ClassDiagram1.cd" />
     <None Include="Properties\Settings.settings">

--- a/Yahtzee/YahtzeeController.cs
+++ b/Yahtzee/YahtzeeController.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Yahtzee
+{
+  public class YahtzeeController
+  {
+    private YahtzeeView view;
+    public YahtzeeModel model;
+    private ScoreboardController scoreboard = new ScoreboardController();
+
+    private List<TeerlingController> teerlingen = new List<TeerlingController>();
+    private int aantalTeerlingen;
+
+    public YahtzeeController()
+		{
+     
+      view = new YahtzeeView(this);
+      //view.Location = new System.Drawing.Point(view.Width + view.Width, view.Location.Y + view.Location.Y);  //Moet nog verder werken om de schermen op andere plaatsen te laten verschijnen.
+      view.Show();  //Laat form verschijnen
+      model = new YahtzeeModel();
+
+      aantalTeerlingen = model.AantalTeerlingen; 
+      scoreboard.model.Numbers = new int[aantalTeerlingen]; 
+
+      for (int i = 0; i < aantalTeerlingen; i++)
+      {
+        //Maak instantie aan van TeerlingController
+        //Voeg teerling toe aan het formulier via YahtzeeView
+        teerlingen.Add(new TeerlingController(i, this));
+        TeerlingView teerlingView = teerlingen[i].getView();
+        view.MakeDice(teerlingView, i);
+      }
+		}
+
+    public ScoreboardView GetScoreView() //Haalt ScoreboardView vanuit ScoreboardController
+    {
+      return scoreboard.getView();
+    }
+
+    public void ScoreChanged(int indexOfTeerling) //Verandert score van één teerling
+    {
+      scoreboard.ChangeScore(indexOfTeerling, teerlingen[indexOfTeerling].model.AantalOgen);
+      scoreboard.UpdateScore();
+    }
+
+    public void ScoreChangedAll() //Verandert score van alle teerlingen
+    {
+      for (int i = 0; i < aantalTeerlingen; i++)
+      {
+        teerlingen[i].getView().SetText();
+        scoreboard.ChangeScore(i, teerlingen[i].model.AantalOgen);
+      }
+      scoreboard.UpdateScore();
+    }
+
+
+
+
+
+  }
+}

--- a/Yahtzee/YahtzeeModel.cs
+++ b/Yahtzee/YahtzeeModel.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Yahtzee
+{
+  public class YahtzeeModel
+  {
+    private int aantalTeerlingen = 5; //, aantalWorpen = 0;
+
+    public int AantalTeerlingen {
+      get { return aantalTeerlingen; } 
+      set { aantalTeerlingen = value; } 
+    }
+
+    //public int AantalWorpen
+    //{
+    //  get { return aantalWorpen; }
+    //  set { aantalWorpen = value; }
+    //}  
+
+  }
+}

--- a/Yahtzee/YahtzeeStart.Designer.cs
+++ b/Yahtzee/YahtzeeStart.Designer.cs
@@ -1,0 +1,107 @@
+﻿namespace Yahtzee
+{
+  partial class YahtzeeStart
+  {
+    /// <summary>
+    /// Required designer variable.
+    /// </summary>
+    private System.ComponentModel.IContainer components = null;
+
+    /// <summary>
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+      if (disposing && (components != null))
+      {
+        components.Dispose();
+      }
+      base.Dispose(disposing);
+    }
+
+    #region Windows Form Designer generated code
+
+    /// <summary>
+    /// Required method for Designer support - do not modify
+    /// the contents of this method with the code editor.
+    /// </summary>
+    private void InitializeComponent()
+    {
+      this.amntLabel = new System.Windows.Forms.Label();
+      this.numberInput = new System.Windows.Forms.TextBox();
+      this.questionPlayerLabel = new System.Windows.Forms.Label();
+      this.startGame = new System.Windows.Forms.Button();
+      this.welcomeLabel = new System.Windows.Forms.Label();
+      this.SuspendLayout();
+      // 
+      // amntLabel
+      // 
+      this.amntLabel.AutoSize = true;
+      this.amntLabel.Location = new System.Drawing.Point(60, 114);
+      this.amntLabel.Name = "amntLabel";
+      this.amntLabel.Size = new System.Drawing.Size(0, 13);
+      this.amntLabel.TabIndex = 1;
+      // 
+      // numberInput
+      // 
+      this.numberInput.Location = new System.Drawing.Point(109, 77);
+      this.numberInput.Name = "numberInput";
+      this.numberInput.Size = new System.Drawing.Size(40, 20);
+      this.numberInput.TabIndex = 2;
+      // 
+      // questionPlayerLabel
+      // 
+      this.questionPlayerLabel.AutoSize = true;
+      this.questionPlayerLabel.Location = new System.Drawing.Point(80, 53);
+      this.questionPlayerLabel.Name = "questionPlayerLabel";
+      this.questionPlayerLabel.Size = new System.Drawing.Size(99, 13);
+      this.questionPlayerLabel.TabIndex = 3;
+      this.questionPlayerLabel.Text = "How many players?";
+      // 
+      // startGame
+      // 
+      this.startGame.Location = new System.Drawing.Point(94, 140);
+      this.startGame.Name = "startGame";
+      this.startGame.Size = new System.Drawing.Size(75, 23);
+      this.startGame.TabIndex = 0;
+      this.startGame.Text = "Start";
+      this.startGame.UseVisualStyleBackColor = true;
+      this.startGame.Click += new System.EventHandler(this.startGame_Click);
+      // 
+      // welcomeLabel
+      // 
+      this.welcomeLabel.AutoSize = true;
+      this.welcomeLabel.Location = new System.Drawing.Point(75, 22);
+      this.welcomeLabel.Name = "welcomeLabel";
+      this.welcomeLabel.Size = new System.Drawing.Size(109, 13);
+      this.welcomeLabel.TabIndex = 4;
+      this.welcomeLabel.Text = "Welcome to Yahtzee!";
+      // 
+      // YahtzeeStart
+      // 
+      this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+      this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+      this.ClientSize = new System.Drawing.Size(284, 196);
+      this.Controls.Add(this.welcomeLabel);
+      this.Controls.Add(this.questionPlayerLabel);
+      this.Controls.Add(this.numberInput);
+      this.Controls.Add(this.amntLabel);
+      this.Controls.Add(this.startGame);
+      this.Name = "YahtzeeStart";
+      this.Text = "Yahtzee";
+      this.ResumeLayout(false);
+      this.PerformLayout();
+
+    }
+
+    #endregion
+
+    private System.Windows.Forms.Label amntLabel;
+    private System.Windows.Forms.TextBox numberInput;
+    private System.Windows.Forms.Label questionPlayerLabel;
+    private System.Windows.Forms.Button startGame;
+    private System.Windows.Forms.Label welcomeLabel;
+
+  }
+}

--- a/Yahtzee/YahtzeeStart.cs
+++ b/Yahtzee/YahtzeeStart.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Yahtzee
+{
+  public partial class YahtzeeStart : Form
+  {
+    int amountOfPlayers;
+
+    public YahtzeeStart()
+    {
+      InitializeComponent();
+    }
+
+    private void startGame_Click(object sender, EventArgs e)
+    {
+      if (Int32.TryParse(numberInput.Text, out amountOfPlayers)) //Als je geen geldig nummer intypt, speel je alleen.
+      {
+        if (amountOfPlayers > 5) { //Max. aantal spelers is 5
+            amountOfPlayers = 5;
+        }
+        amntLabel.Text = "You have chosen " + amountOfPlayers + " player(s).";
+      }
+      else
+      {
+        amountOfPlayers = 1;
+        amntLabel.Text = "You have chosen " + amountOfPlayers + " player.";
+      }
+
+      for (int i = 0; i < amountOfPlayers; i++)
+      {
+        YahtzeeController controller = new YahtzeeController();
+        //controller.model.AantalTeerlingen = amountOfDice; //Waarschijnlijk nutteloos als we met echte scoresysteem gaan werken.
+        
+        //ShowPlayerScores();
+      }     
+    }
+
+    public void ShowPlayerScores() //Moet naar controller van ScoreboardGlobalPlayer
+    {
+      //int[] players = new int[amountOfPlayers];
+      for (int i = 0; i < amountOfPlayers; i++)
+      {
+        //players.Add(new ScoreboardGlobalPlayerController(i, this));
+        //ScoreboardGlobalPlayerView scoreboardView = players[i].getView();
+        ScoreboardGlobalPlayerView scoreboardView = new ScoreboardGlobalPlayerView();
+        scoreboardView.Location = new System.Drawing.Point(i * scoreboardView.Width, 150);
+        Controls.Add(scoreboardView);
+        Size = new Size(Size.Width, Size.Width);
+      }
+    }
+
+  }
+}

--- a/Yahtzee/YahtzeeStart.resx
+++ b/Yahtzee/YahtzeeStart.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
Kunt al meerdere vensters opendoen van Yahtzee, maar er is nog geen communicatie tussen deze vensters.

Buiten het splitsen zijn extra dingen aangepast:
- AantalWorpen verwijdert (in commentaar gezet momenteel) van Yahtzee. Deze werd niet gebruikt. Het is verplaats naar TeerlingModel en het aantal keren tellen is van de TeerlingView naar de TeerlingController verplaatst.
- Vijf teerlingen, aangezien we met het echte scoresysteem gaan werken.
- Index van de teerling wordt meegegeven als de score van één teerling moet veranderd worden. Minder overbodige code zo. 
- Er is een globale scoreboard view voor een Player aangemaakt, maar is nog niet werkend.
